### PR TITLE
Add missing condition for geoip volume mount

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -111,8 +111,10 @@ spec:
           volumeMounts:
             - name: app-tmp
               mountPath: /app/tmp
+            {{- if .Values.geolocation.enabled }}
             - name: geoip
               mountPath: /geoip/
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
When not using GeoIP, there is a condition missing to disable the GeoIP volume mount. This PR adds this condition.