### PR TITLE
Update to plausible 1.3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: plausible-analytics
 description: A Helm Chart for Plausible Analytics - a simple and privacy-friendly alternative to Google Analytics
 type: application
-version: 0.2.2
-appVersion: v1.1.1
+version: 0.2.3
+appVersion: v1.3.0
 home: https://plausible.io/
 icon: https://docs.plausible.io/img/logo.svg
 keywords:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -232,7 +232,7 @@ spec:
             - name: DISABLE_REGISTRATION
               value: {{ .Values.disableRegistration | toString | quote }}
             {{- end }}
-            {{- if .Values.disableAuth }}
+            {{- if .Values.baseURL }}
             - name: BASE_URL
               value: {{ .Values.baseURL | toString | quote }}
             {{- end }}


### PR DESCRIPTION
To make it work I had to fix the deployment.yaml template that checked the wrong value on L235.
This prevented the init container to start on plausible 1.3, as the `BASE_URL` env variable is required to be non-empty.