### PR TITLE
use ingress stable api

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "plausible-analytics.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -38,9 +40,19 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            {{ if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
+              {{ if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{ else -}}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Fix #13 

BC has been retained and the hard-coded `pathType: ImplementationSpecific` has been added.
To allow customization of `pathType` a small BC break in the `values.yaml` file should be probably unavoidable.