### PR TITLE
Add secretKeyBase param

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ adminUser:
   name:   # Display name admin user
   password: # Admin user password
 
-# SECRET_KEY_BASE is Helm randAlphaNum 90
+secretKeyBase: "" # Defaults to random 90 characters alphanumeric string if not set
 
 database: # Postgres Database
   enabled: true

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -22,7 +22,11 @@ data:
   {{- if .Values.clickhouse.url }}
   CLICKHOUSE_DATABASE_URL: {{ .Values.clickhouse.url | toString | b64enc }}
   {{- end }}
+  {{- if .Values.secretKeyBase }}
+  SECRET_KEY_BASE: {{ .Values.secretKeyBase | toString | b64enc }}
+  {{- else }}
   SECRET_KEY_BASE: {{ randAlphaNum 90 | toString | b64enc }}
+  {{- end }}
   {{- if .Values.smtp.enabled }}
   {{- if .Values.smtp.mailer.emailAddress }}
   MAILER_EMAIL: {{ .Values.smtp.mailer.emailAddress | toString | b64enc }}

--- a/values.yaml
+++ b/values.yaml
@@ -12,7 +12,7 @@ adminUser:
   name:   # Display name admin user
   password: # Admin user password
 
-# SECRET_KEY_BASE is Helm randAlphaNum 90
+secretKeyBase: "" # Defaults to random 90 characters alphanumeric string if not set
 
 database: # Postgres Database
   enabled: true


### PR DESCRIPTION
Some tools like ArgoCD [do not work properly with randomly generated values](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#random-data), so it would be better to add optional `secretKeyBase` parameter and only generate it if it has not been provided.